### PR TITLE
Return camera to player after enemy turn and allow mouse dragging

### DIFF
--- a/Assets/Scripts/CameraController.cs
+++ b/Assets/Scripts/CameraController.cs
@@ -11,7 +11,10 @@ public class CameraController : MonoBehaviour
     }
 
     public float moveSpeed;
+    public float dragSpeed = 1f;
     private Vector3 moveTarget;
+    private Vector3 dragOrigin;
+    private bool isDragging;
 
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
@@ -22,9 +25,33 @@ public class CameraController : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if (moveTarget != transform.position)
+        HandleDrag();
+
+        if (!isDragging && moveTarget != transform.position)
         {
             transform.position = Vector3.MoveTowards(transform.position, moveTarget, moveSpeed * Time.deltaTime);
+        }
+    }
+
+    private void HandleDrag()
+    {
+        if (Input.GetMouseButtonDown(0))
+        {
+            isDragging = true;
+            dragOrigin = Input.mousePosition;
+        }
+        else if (Input.GetMouseButtonUp(0))
+        {
+            isDragging = false;
+        }
+
+        if (isDragging && Input.GetMouseButton(0))
+        {
+            Vector3 delta = Input.mousePosition - dragOrigin;
+            Vector3 move = new Vector3(-delta.x, 0f, -delta.y) * dragSpeed * Time.deltaTime;
+            transform.Translate(move, Space.World);
+            moveTarget = transform.position;
+            dragOrigin = Input.mousePosition;
         }
     }
 

--- a/Assets/Scripts/CharacterController.cs
+++ b/Assets/Scripts/CharacterController.cs
@@ -34,10 +34,20 @@ public class CharacterController : MonoBehaviour
                 CameraController.instance.SetMoveTarget(transform.position);
             }
         }
+        else if (isMoving)
+        {
+            isMoving = false;
+
+            if (GameManager.instance.activePlayer == this)
+            {
+                GameManager.instance.NextTurn();
+            }
+        }
     }
 
     public void MoveToPoint(Vector3 pointToMoveTo)
     {
         moveTarget = pointToMoveTo;
+        isMoving = true;
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,4 +1,3 @@
-using NUnit.Framework;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -16,6 +15,8 @@ public class GameManager : MonoBehaviour
     public List<CharacterController> allChars = new List<CharacterController>();
     public List<CharacterController> playerTeam = new List<CharacterController>();
     public List<CharacterController> enemyTeam = new List<CharacterController>();
+
+    private int currentCharIndex;
 
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
@@ -39,6 +40,24 @@ public class GameManager : MonoBehaviour
         allChars.AddRange(playerTeam);
         allChars.AddRange(enemyTeam);
 
+        currentCharIndex = 0;
+        if(allChars.Count > 0)
+        {
+            activePlayer = allChars[currentCharIndex];
+            CameraController.instance.SetMoveTarget(activePlayer.transform.position);
+        }
+    }
+
+    public void NextTurn()
+    {
+        currentCharIndex++;
+        if (currentCharIndex >= allChars.Count)
+        {
+            currentCharIndex = 0;
+        }
+
+        activePlayer = allChars[currentCharIndex];
+        CameraController.instance.SetMoveTarget(activePlayer.transform.position);
     }
 
     // Update is called once per frame


### PR DESCRIPTION
## Summary
- add mouse-drag movement to the camera so it can be repositioned with the left mouse button
- cycle active character turns and recenter camera on the next actor
- advance turns after a character finishes moving, returning the view to the player after enemy actions

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68909be710a88328b35f64ad4daca3d1