### PR TITLE
Focus camera on active player and allow manual panning

### DIFF
--- a/Assets/Scripts/CameraController.cs
+++ b/Assets/Scripts/CameraController.cs
@@ -11,7 +11,9 @@ public class CameraController : MonoBehaviour
     }
 
     public float moveSpeed;
+    public float dragSpeed;
     private Vector3 moveTarget;
+    private Vector3 lastMousePos;
 
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
@@ -22,7 +24,20 @@ public class CameraController : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if (moveTarget != transform.position)
+        if (Input.GetMouseButtonDown(0))
+        {
+            lastMousePos = Input.mousePosition;
+            moveTarget = transform.position;
+        }
+        else if (Input.GetMouseButton(0))
+        {
+            Vector3 delta = Input.mousePosition - lastMousePos;
+            lastMousePos = Input.mousePosition;
+            Vector3 move = new Vector3(-delta.x, 0f, -delta.y) * dragSpeed * Time.deltaTime;
+            transform.position += move;
+            moveTarget = transform.position;
+        }
+        else if (moveTarget != transform.position)
         {
             transform.position = Vector3.MoveTowards(transform.position, moveTarget, moveSpeed * Time.deltaTime);
         }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -45,6 +45,7 @@ public class GameManager : MonoBehaviour
         if (allChars.Count > 0)
         {
             activePlayer = allChars[currentCharIndex];
+            CameraController.instance.SetMoveTarget(activePlayer.transform.position);
 
             if (activePlayer.isEnemy)
             {
@@ -87,6 +88,8 @@ public class GameManager : MonoBehaviour
         }
 
         activePlayer = allChars[currentCharIndex];
+
+        CameraController.instance.SetMoveTarget(activePlayer.transform.position);
 
         if (activePlayer.isEnemy)
         {


### PR DESCRIPTION
## Summary
- Keep camera centered on whoever's turn it is
- Allow dragging the camera with the left mouse button

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68909f01a8b88328a5fc5322545fca02