### PR TITLE
Add hitpoint display above characters

### DIFF
--- a/Assets/Scripts/CharacterController.cs
+++ b/Assets/Scripts/CharacterController.cs
@@ -30,6 +30,7 @@ public class CharacterController : MonoBehaviour
         hpText.alignment = TextAlignmentOptions.Center;
         hpText.fontSize = 3f;
         hpText.color = Color.red;
+        hpText.font = TMP_Settings.defaultFontAsset;
         hpText.text = hitPoints.ToString();
     }
 

--- a/Assets/Scripts/CharacterController.cs
+++ b/Assets/Scripts/CharacterController.cs
@@ -30,7 +30,18 @@ public class CharacterController : MonoBehaviour
         hpText.alignment = TextAlignmentOptions.Center;
         hpText.fontSize = 3f;
         hpText.color = Color.red;
-        hpText.font = TMP_Settings.defaultFontAsset;
+
+        // Assign a valid font asset so the HP value renders instead of the TMP placeholder
+        TMP_FontAsset fontAsset = TMP_Settings.defaultFontAsset;
+        if (fontAsset == null)
+        {
+            fontAsset = Resources.Load<TMP_FontAsset>("Fonts & Materials/LiberationSans SDF");
+        }
+        if (fontAsset != null)
+        {
+            hpText.font = fontAsset;
+        }
+
         hpText.text = hitPoints.ToString();
     }
 

--- a/Assets/Scripts/CharacterController.cs
+++ b/Assets/Scripts/CharacterController.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.AI;
+using TMPro;
 
 public class CharacterController : MonoBehaviour
 {
@@ -13,10 +14,23 @@ public class CharacterController : MonoBehaviour
 
     public bool isEnemy;
 
+    public int hitPoints = 100;
+    private TextMeshPro hpText;
+    public Vector3 hpOffset = new Vector3(0f, 2f, 0f);
+
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
         moveTarget = transform.position;
+
+        GameObject hpObj = new GameObject("HPDisplay");
+        hpObj.transform.SetParent(transform);
+        hpObj.transform.localPosition = hpOffset;
+        hpText = hpObj.AddComponent<TextMeshPro>();
+        hpText.alignment = TextAlignmentOptions.Center;
+        hpText.fontSize = 3f;
+        hpText.color = Color.red;
+        hpText.text = hitPoints.ToString();
     }
 
     // Update is called once per frame
@@ -33,6 +47,11 @@ public class CharacterController : MonoBehaviour
             {
                 CameraController.instance.SetMoveTarget(transform.position);
             }
+        }
+
+        if (hpText != null)
+        {
+            hpText.text = hitPoints.ToString();
         }
     }
 

--- a/Assets/Scripts/CharacterController.cs
+++ b/Assets/Scripts/CharacterController.cs
@@ -67,7 +67,8 @@ public class CharacterController : MonoBehaviour
             if (Camera.main != null)
             {
                 hpText.transform.LookAt(Camera.main.transform);
-                hpText.transform.Rotate(0f, 180f, 0f);
+                // Rotate 90 degrees around the Y axis so the text aligns correctly
+                hpText.transform.Rotate(0f, 90f, 0f);
             }
         }
     }

--- a/Assets/Scripts/CharacterController.cs
+++ b/Assets/Scripts/CharacterController.cs
@@ -64,6 +64,11 @@ public class CharacterController : MonoBehaviour
         if (hpText != null)
         {
             hpText.text = hitPoints.ToString();
+            if (Camera.main != null)
+            {
+                hpText.transform.LookAt(Camera.main.transform);
+                hpText.transform.Rotate(0f, 180f, 0f);
+            }
         }
     }
 

--- a/Assets/Scripts/CharacterController.cs
+++ b/Assets/Scripts/CharacterController.cs
@@ -66,9 +66,10 @@ public class CharacterController : MonoBehaviour
             hpText.text = hitPoints.ToString();
             if (Camera.main != null)
             {
-                hpText.transform.LookAt(Camera.main.transform);
-                // Rotate 90 degrees around the Y axis so the text aligns correctly
-                hpText.transform.Rotate(0f, 90f, 0f);
+                Vector3 camPos = Camera.main.transform.position;
+                Vector3 dir = hpText.transform.position - camPos;
+                hpText.transform.rotation = Quaternion.LookRotation(dir);
+                hpText.transform.rotation *= Quaternion.Euler(0f, 90f, 0f);
             }
         }
     }


### PR DESCRIPTION
## Summary
- display hit points above player and enemy using TextMeshPro
- initialize each character with 100 HP

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_6890c2a4546c83288f5d18a047b9bdde