### PR TITLE
Add attack action menu

### DIFF
--- a/Assets/Scripts/ActionMenu.cs
+++ b/Assets/Scripts/ActionMenu.cs
@@ -1,0 +1,84 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class ActionMenu : MonoBehaviour
+{
+    public static ActionMenu instance;
+
+    [Header("UI References")]
+    public Button actionButton;
+    public GameObject dropUpPanel;
+    public Button attackButton;
+    public Button magicButton;
+    public Button restButton;
+
+    private void Awake()
+    {
+        instance = this;
+    }
+
+    void Start()
+    {
+        HideMenu();
+
+        if (actionButton != null)
+        {
+            actionButton.onClick.AddListener(ToggleDropUp);
+        }
+
+        if (attackButton != null)
+        {
+            attackButton.onClick.AddListener(Attack);
+        }
+    }
+
+    public void ShowMenu()
+    {
+        if (actionButton != null)
+        {
+            actionButton.gameObject.SetActive(true);
+        }
+
+        if (dropUpPanel != null)
+        {
+            dropUpPanel.SetActive(false);
+        }
+    }
+
+    public void HideMenu()
+    {
+        if (actionButton != null)
+        {
+            actionButton.gameObject.SetActive(false);
+        }
+
+        if (dropUpPanel != null)
+        {
+            dropUpPanel.SetActive(false);
+        }
+    }
+
+    private void ToggleDropUp()
+    {
+        if (dropUpPanel != null)
+        {
+            dropUpPanel.SetActive(!dropUpPanel.activeSelf);
+        }
+    }
+
+    private void Attack()
+    {
+        if (GameManager.instance.enemyTeam.Count > 0)
+        {
+            CharacterController enemy = GameManager.instance.enemyTeam[0];
+            int damage = Random.Range(10, 21);
+            enemy.TakeDamage(damage);
+            Debug.Log($"Enemy {enemy.name} takes {damage} damage. HP left: {enemy.hitPoints}");
+        }
+
+        if (dropUpPanel != null)
+        {
+            dropUpPanel.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/ActionMenu.cs.meta
+++ b/Assets/Scripts/ActionMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1d82622cff56441ab0c76ae812a0b9fe

--- a/Assets/Scripts/CharacterController.cs
+++ b/Assets/Scripts/CharacterController.cs
@@ -13,6 +13,8 @@ public class CharacterController : MonoBehaviour
 
     public bool isEnemy;
 
+    public int hitPoints = 100;
+
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
@@ -34,10 +36,31 @@ public class CharacterController : MonoBehaviour
                 CameraController.instance.SetMoveTarget(transform.position);
             }
         }
+        else if (isMoving)
+        {
+            isMoving = false;
+
+            if (GameManager.instance.activePlayer == this)
+            {
+                ActionMenu.instance.ShowMenu();
+            }
+        }
     }
 
     public void MoveToPoint(Vector3 pointToMoveTo)
     {
         moveTarget = pointToMoveTo;
+        isMoving = true;
+        ActionMenu.instance.HideMenu();
+    }
+
+    public void TakeDamage(int amount)
+    {
+        hitPoints -= amount;
+
+        if (hitPoints < 0)
+        {
+            hitPoints = 0;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- show an action menu after a player reaches a hexagon
- implement Attack option that damages an enemy for 10-20 hit points
- track character hit points and update menu visibility with movement

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6890da6eb25c8328b1409d98678b7d18