### PR TITLE
Show action button after movement and wait for player action

### DIFF
--- a/Assets/Scripts/ActionMenu.cs
+++ b/Assets/Scripts/ActionMenu.cs
@@ -30,6 +30,16 @@ public class ActionMenu : MonoBehaviour
         {
             attackButton.onClick.AddListener(Attack);
         }
+
+        if (magicButton != null)
+        {
+            magicButton.onClick.AddListener(Magic);
+        }
+
+        if (restButton != null)
+        {
+            restButton.onClick.AddListener(Rest);
+        }
     }
 
     public void ShowMenu()
@@ -76,9 +86,27 @@ public class ActionMenu : MonoBehaviour
             Debug.Log($"Enemy {enemy.name} takes {damage} damage. HP left: {enemy.hitPoints}");
         }
 
+        CompletePlayerAction();
+    }
+
+    private void Magic()
+    {
+        CompletePlayerAction();
+    }
+
+    private void Rest()
+    {
+        CompletePlayerAction();
+    }
+
+    private void CompletePlayerAction()
+    {
         if (dropUpPanel != null)
         {
             dropUpPanel.SetActive(false);
         }
+
+        HideMenu();
+        GameManager.instance.EndTurn();
     }
 }

--- a/Assets/Scripts/CharacterController.cs
+++ b/Assets/Scripts/CharacterController.cs
@@ -76,6 +76,12 @@ public class CharacterController : MonoBehaviour
         {
             GameManager.instance.OnPlayerMoveComplete();
             playerMovePending = false;
+            isMoving = false;
+
+            if (GameManager.instance.activePlayer == this)
+            {
+                ActionMenu.instance.ShowMenu();
+            }
         }
     }
 
@@ -118,33 +124,13 @@ public class CharacterController : MonoBehaviour
         if (newTarget != playerPos && step != Vector3.zero)
         {
             moveTarget = newTarget;
+
             if (hpText != null)
             {
-                hpText.text = hitPoints.ToString();
                 hpText.text = hitPoints.ToString();
                 if (Camera.main != null)
                 {
                     hpText.transform.LookAt(Camera.main.transform);
-                }
-                Vector3 camPos = Camera.main.transform.position;
-                Vector3 dir = hpText.transform.position - camPos;
-            }
-            else if (isMoving)
-            {
-                isMoving = false;
-
-                if (GameManager.instance.activePlayer == this)
-                {
-                    ActionMenu.instance.ShowMenu();
-                }
-                else if (isMoving)
-                {
-                    isMoving = false;
-
-                    if (GameManager.instance.activePlayer == this)
-                    {
-                        ActionMenu.instance.ShowMenu();
-                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Show action menu when the active player finishes moving
- End the player's turn and hide the menu when an action is chosen

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891ac9613d48328bcb2f74f312c5a94