### PR TITLE
Populate DropUpPanel with action buttons

### DIFF
--- a/Assets/Scripts/ActionMenu.cs
+++ b/Assets/Scripts/ActionMenu.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 
 public class ActionMenu : MonoBehaviour
 {
@@ -8,9 +9,11 @@ public class ActionMenu : MonoBehaviour
     [Header("UI References")]
     public Button actionButton;
     public GameObject dropUpPanel;
-    public Button attackButton;
-    public Button magicButton;
-    public Button restButton;
+    public Button buttonPrefab;
+
+    private Button attackButton;
+    private Button magicButton;
+    private Button restButton;
 
     private void Awake()
     {
@@ -26,19 +29,11 @@ public class ActionMenu : MonoBehaviour
             actionButton.onClick.AddListener(ToggleDropUp);
         }
 
-        if (attackButton != null)
+        if (dropUpPanel != null && buttonPrefab != null)
         {
-            attackButton.onClick.AddListener(Attack);
-        }
-
-        if (magicButton != null)
-        {
-            magicButton.onClick.AddListener(Magic);
-        }
-
-        if (restButton != null)
-        {
-            restButton.onClick.AddListener(Rest);
+            attackButton = CreateMenuButton("Attack", Attack, 0);
+            magicButton = CreateMenuButton("Magic", Magic, 1);
+            restButton = CreateMenuButton("Rest", Rest, 2);
         }
     }
 
@@ -108,5 +103,25 @@ public class ActionMenu : MonoBehaviour
 
         HideMenu();
         GameManager.instance.EndTurn();
+    }
+
+    private Button CreateMenuButton(string label, UnityEngine.Events.UnityAction action, int index)
+    {
+        Button btn = Instantiate(buttonPrefab, dropUpPanel.transform);
+        btn.onClick.AddListener(action);
+
+        TMP_Text text = btn.GetComponentInChildren<TMP_Text>();
+        if (text != null)
+        {
+            text.text = label;
+        }
+
+        RectTransform rect = btn.GetComponent<RectTransform>();
+        if (rect != null)
+        {
+            rect.anchoredPosition = new Vector2(0, -index * rect.sizeDelta.y);
+        }
+
+        return btn;
     }
 }


### PR DESCRIPTION
## Summary
- Dynamically generate action buttons inside the DropUpPanel
- Add helper to instantiate buttons with proper labels and hooks

## Testing
- `npm test` *(fails: Could not read package.json)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891b148e61c83289ab08f41b05cbfb6