### PR TITLE
Implement turn-based battle flow

### DIFF
--- a/Assets/Scripts/CharacterController.cs
+++ b/Assets/Scripts/CharacterController.cs
@@ -161,10 +161,18 @@ public class CharacterController : MonoBehaviour
     public void TakeDamage(int amount)
     {
         hitPoints -= amount;
-
         if (hitPoints < 0)
         {
             hitPoints = 0;
+        }
+
+        if (hpText != null)
+        {
+            hpText.text = hitPoints.ToString();
+            if (Camera.main != null)
+            {
+                hpText.transform.LookAt(Camera.main.transform);
+            }
         }
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -58,7 +58,7 @@ public class GameManager : MonoBehaviour
             activePlayer = playerTeam[0];
         }
 
-        if (activePlayer != null)
+        if (activePlayer != null && !activePlayer.isEnemy)
         {
             ActionMenu.instance.ShowMenu();
         }
@@ -108,6 +108,7 @@ public class GameManager : MonoBehaviour
     public void EndTurn()
     {
         BattleMenu.instance?.Hide();
+        ActionMenu.instance.HideMenu();
 
         currentCharIndex++;
         if (currentCharIndex >= allChars.Count)
@@ -123,19 +124,26 @@ public class GameManager : MonoBehaviour
         {
             StartCoroutine(EnemyTurn());
         }
+        else
+        {
+            ActionMenu.instance.ShowMenu();
+        }
     }
 
     private IEnumerator EnemyTurn()
     {
         yield return new WaitForSeconds(0.5f);
 
-        List<MovePoint> possibleMoves = MoveGrid.instance.GetPointsInRange(activePlayer.transform.position, 5);
-
-        if (possibleMoves.Count > 0)
+        if (playerTeam.Count > 0)
         {
-            int index = Random.Range(0, possibleMoves.Count);
-            activePlayer.MoveToPoint(possibleMoves[index].transform.position);
+            CharacterController player = playerTeam[0];
+            int damage = Random.Range(10, 21);
+            player.TakeDamage(damage);
+            Debug.Log($"Player {player.name} takes {damage} damage. HP left: {player.hitPoints}");
         }
+
+        yield return new WaitForSeconds(0.5f);
+        EndTurn();
     }
     public void OnPlayerMoveComplete()
     {


### PR DESCRIPTION
## Summary
- alternate turns between player and enemy in Battle_1
- enemy automatically attacks player and returns control
- update HP display after taking damage

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891c67c1070832883ef4ad79bcc8b25