### PR TITLE
Add Fire and Rain magic options

### DIFF
--- a/Assets/Scripts/ActionMenu.cs
+++ b/Assets/Scripts/ActionMenu.cs
@@ -13,6 +13,9 @@ public class ActionMenu : MonoBehaviour
     [SerializeField] private Button magicButton;
     [SerializeField] private Button restButton;
 
+    [SerializeField] private Button fireButton;
+    [SerializeField] private Button rainButton;
+
     private void Awake()
     {
         instance = this;
@@ -38,6 +41,17 @@ public class ActionMenu : MonoBehaviour
         if (restButton != null)
         {
             restButton.onClick.AddListener(Rest);
+        }
+
+        if (fireButton != null)
+        {
+            fireButton.gameObject.SetActive(false);
+            fireButton.onClick.AddListener(CastFire);
+        }
+        if (rainButton != null)
+        {
+            rainButton.gameObject.SetActive(false);
+            rainButton.onClick.AddListener(CastRain);
         }
     }
 
@@ -90,10 +104,27 @@ public class ActionMenu : MonoBehaviour
 
     private void Magic()
     {
-        CompletePlayerAction();
+        if (fireButton == null || rainButton == null)
+        {
+            return;
+        }
+
+        bool show = !fireButton.gameObject.activeSelf;
+        fireButton.gameObject.SetActive(show);
+        rainButton.gameObject.SetActive(show);
     }
 
     private void Rest()
+    {
+        CompletePlayerAction();
+    }
+
+    private void CastFire()
+    {
+        CompletePlayerAction();
+    }
+
+    private void CastRain()
     {
         CompletePlayerAction();
     }


### PR DESCRIPTION
## Summary
- show Fire and Rain buttons when Magic is tapped
- reference Fire and Rain buttons directly in the hierarchy instead of creating them at runtime

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6891d5c5c61c8328995b7a7093afe40e