### PR TITLE
Add battle action effects

### DIFF
--- a/Assets/Scripts/ActionMenu.cs
+++ b/Assets/Scripts/ActionMenu.cs
@@ -105,16 +105,46 @@ public class ActionMenu : MonoBehaviour
 
     private void Rest()
     {
+        CharacterController player = GameManager.instance.activePlayer;
+        if (player != null && !player.isEnemy)
+        {
+            int healAmount = 30;
+            player.Heal(healAmount);
+            Debug.Log($"Player {player.name} rests and recovers {healAmount} HP. HP now: {player.hitPoints}");
+        }
+
         CompletePlayerAction();
     }
 
     private void CastFire()
     {
+        if (GameManager.instance.enemyTeam.Count > 0)
+        {
+            CharacterController enemy = GameManager.instance.enemyTeam[0];
+            int damage = Random.Range(15, 31);
+            enemy.TakeDamage(damage);
+            Debug.Log($"Enemy {enemy.name} takes {damage} fire damage. HP left: {enemy.hitPoints}");
+        }
+
+        fireButton.gameObject.SetActive(false);
+        rainButton.gameObject.SetActive(false);
+
         CompletePlayerAction();
     }
 
     private void CastRain()
     {
+        if (GameManager.instance.enemyTeam.Count > 0)
+        {
+            CharacterController enemy = GameManager.instance.enemyTeam[0];
+            int damage = Random.Range(12, 36);
+            enemy.TakeDamage(damage);
+            Debug.Log($"Enemy {enemy.name} takes {damage} rain damage. HP left: {enemy.hitPoints}");
+        }
+
+        fireButton.gameObject.SetActive(false);
+        rainButton.gameObject.SetActive(false);
+
         CompletePlayerAction();
     }
 

--- a/Assets/Scripts/CharacterController.cs
+++ b/Assets/Scripts/CharacterController.cs
@@ -175,4 +175,22 @@ public class CharacterController : MonoBehaviour
             }
         }
     }
+
+    public void Heal(int amount)
+    {
+        hitPoints += amount;
+        if (hitPoints > 100)
+        {
+            hitPoints = 100;
+        }
+
+        if (hpText != null)
+        {
+            hpText.text = hitPoints.ToString();
+            if (Camera.main != null)
+            {
+                hpText.transform.LookAt(Camera.main.transform);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Implement Rest to heal player for up to 30 HP capped at 100.
- Add Fire and Rain spells with damage ranges of 15-30 and 12-35 respectively.
- Introduce Heal helper and ensure buttons reset after casting.

## Testing
- `dotnet --version` *(fails: command not found)*
- `mcs --version` *(fails: command not found)*
- `csc` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_6891e24ae9448328966f59b551d28449