### PR TITLE
Hide action menu after actions

### DIFF
--- a/Assets/Scripts/ActionMenu.cs
+++ b/Assets/Scripts/ActionMenu.cs
@@ -156,11 +156,6 @@ public class ActionMenu : MonoBehaviour
 
     private void CompletePlayerAction()
     {
-        if (dropUpPanel != null)
-        {
-            dropUpPanel.SetActive(false);
-        }
-
         HideMenu();
         GameManager.instance.EndTurn();
     }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -58,11 +58,7 @@ public class GameManager : MonoBehaviour
             activePlayer = playerTeam[0];
         }
 
-        if (activePlayer != null && !activePlayer.isEnemy)
-        {
-            ActionMenu.instance.ShowMenu();
-        }
-
+        // Allow action menu to appear only after the player finishes a move.
     }
 
     public void SelectCharacter(CharacterController cc)
@@ -124,10 +120,7 @@ public class GameManager : MonoBehaviour
         {
             StartCoroutine(EnemyTurn());
         }
-        else
-        {
-            ActionMenu.instance.ShowMenu();
-        }
+        // The action menu will be displayed once the new active player finishes moving.
     }
 
     private IEnumerator EnemyTurn()


### PR DESCRIPTION
## Summary
- show action menu only after a player completes movement
- keep action menu hidden after performing an action

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 errors when fetching repositories)*

------
https://chatgpt.com/codex/tasks/task_e_6891e99295d08328bbbd2d313fa5ba27