### PR TITLE
Delay enemy action until after player attacks

### DIFF
--- a/Assets/Scripts/CharacterController.cs
+++ b/Assets/Scripts/CharacterController.cs
@@ -77,7 +77,6 @@ public class CharacterController : MonoBehaviour
 
         if (!isEnemy && playerMovePending && Vector3.Distance(transform.position, moveTarget) < 0.01f)
         {
-            GameManager.instance.OnPlayerMoveComplete();
             playerMovePending = false;
             isMoving = false;
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -106,6 +106,13 @@ public class GameManager : MonoBehaviour
         BattleMenu.instance?.Hide();
         ActionMenu.instance.HideMenu();
 
+        bool playerFinishedTurn = !activePlayer.isEnemy;
+
+        if (playerFinishedTurn)
+        {
+            turnCounter++;
+        }
+
         currentCharIndex++;
         if (currentCharIndex >= allChars.Count)
         {
@@ -137,9 +144,5 @@ public class GameManager : MonoBehaviour
 
         yield return new WaitForSeconds(0.5f);
         EndTurn();
-    }
-    public void OnPlayerMoveComplete()
-    {
-        turnCounter++;
     }
 }


### PR DESCRIPTION
## Summary
- enemy reacts only after the player completes a full turn
- move complete no longer advances turn counter immediately

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689799cc62d483288cb28ffdc4487739