### PR TITLE
Restrict attacks based on distance

### DIFF
--- a/Assets/Scripts/ActionMenu.cs
+++ b/Assets/Scripts/ActionMenu.cs
@@ -66,6 +66,8 @@ public class ActionMenu : MonoBehaviour
         {
             dropUpPanel.SetActive(false);
         }
+
+        UpdateButtonStates();
     }
 
     public void HideMenu()
@@ -86,20 +88,31 @@ public class ActionMenu : MonoBehaviour
         if (dropUpPanel != null)
         {
             dropUpPanel.SetActive(!dropUpPanel.activeSelf);
+            if (dropUpPanel.activeSelf)
+            {
+                UpdateButtonStates();
+            }
         }
     }
 
     private void Attack()
     {
-        if (GameManager.instance.enemyTeam.Count > 0)
+        if (GameManager.instance.enemyTeam.Count > 0 && GameManager.instance.activePlayer != null)
         {
             CharacterController enemy = GameManager.instance.enemyTeam[0];
-            int damage = Random.Range(10, 21);
-            enemy.TakeDamage(damage);
-            Debug.Log($"Enemy {enemy.name} takes {damage} damage. HP left: {enemy.hitPoints}");
+            float distance = Vector3.Distance(GameManager.instance.activePlayer.transform.position, enemy.transform.position);
+            if (distance <= 2f)
+            {
+                int damage = Random.Range(10, 21);
+                enemy.TakeDamage(damage);
+                Debug.Log($"Enemy {enemy.name} takes {damage} damage. HP left: {enemy.hitPoints}");
+                CompletePlayerAction();
+            }
+            else
+            {
+                Debug.Log("Enemy is too far to attack.");
+            }
         }
-
-        CompletePlayerAction();
     }
 
     private void Magic()
@@ -107,6 +120,10 @@ public class ActionMenu : MonoBehaviour
         bool show = !fireButton.gameObject.activeSelf;
         fireButton.gameObject.SetActive(show);
         rainButton.gameObject.SetActive(show);
+        if (show)
+        {
+            UpdateButtonStates();
+        }
     }
 
     private void Rest()
@@ -124,39 +141,80 @@ public class ActionMenu : MonoBehaviour
 
     private void CastFire()
     {
-        if (GameManager.instance.enemyTeam.Count > 0)
+        if (GameManager.instance.enemyTeam.Count > 0 && GameManager.instance.activePlayer != null)
         {
             CharacterController enemy = GameManager.instance.enemyTeam[0];
-            int damage = Random.Range(15, 31);
-            enemy.TakeDamage(damage);
-            Debug.Log($"Enemy {enemy.name} takes {damage} fire damage. HP left: {enemy.hitPoints}");
+            float distance = Vector3.Distance(GameManager.instance.activePlayer.transform.position, enemy.transform.position);
+            if (distance <= 4f)
+            {
+                int damage = Random.Range(15, 31);
+                enemy.TakeDamage(damage);
+                Debug.Log($"Enemy {enemy.name} takes {damage} fire damage. HP left: {enemy.hitPoints}");
+                fireButton.gameObject.SetActive(false);
+                rainButton.gameObject.SetActive(false);
+                CompletePlayerAction();
+            }
+            else
+            {
+                Debug.Log("Enemy is too far to cast Fire.");
+            }
         }
-
-        fireButton.gameObject.SetActive(false);
-        rainButton.gameObject.SetActive(false);
-
-        CompletePlayerAction();
     }
 
     private void CastRain()
     {
-        if (GameManager.instance.enemyTeam.Count > 0)
+        if (GameManager.instance.enemyTeam.Count > 0 && GameManager.instance.activePlayer != null)
         {
             CharacterController enemy = GameManager.instance.enemyTeam[0];
-            int damage = Random.Range(12, 36);
-            enemy.TakeDamage(damage);
-            Debug.Log($"Enemy {enemy.name} takes {damage} rain damage. HP left: {enemy.hitPoints}");
+            float distance = Vector3.Distance(GameManager.instance.activePlayer.transform.position, enemy.transform.position);
+            if (distance <= 4f)
+            {
+                int damage = Random.Range(12, 36);
+                enemy.TakeDamage(damage);
+                Debug.Log($"Enemy {enemy.name} takes {damage} rain damage. HP left: {enemy.hitPoints}");
+                fireButton.gameObject.SetActive(false);
+                rainButton.gameObject.SetActive(false);
+                CompletePlayerAction();
+            }
+            else
+            {
+                Debug.Log("Enemy is too far to cast Rain.");
+            }
         }
-
-        fireButton.gameObject.SetActive(false);
-        rainButton.gameObject.SetActive(false);
-
-        CompletePlayerAction();
     }
 
     private void CompletePlayerAction()
     {
         HideMenu();
         GameManager.instance.EndTurn();
+    }
+
+    private void UpdateButtonStates()
+    {
+        if (attackButton == null || fireButton == null || rainButton == null)
+        {
+            return;
+        }
+
+        bool playerExists = GameManager.instance != null && GameManager.instance.activePlayer != null;
+        bool enemyExists = GameManager.instance != null && GameManager.instance.enemyTeam.Count > 0;
+
+        if (!playerExists || !enemyExists)
+        {
+            attackButton.interactable = false;
+            fireButton.interactable = false;
+            rainButton.interactable = false;
+            return;
+        }
+
+        CharacterController player = GameManager.instance.activePlayer;
+        CharacterController enemy = GameManager.instance.enemyTeam[0];
+
+        float distance = Vector3.Distance(player.transform.position, enemy.transform.position);
+
+        attackButton.interactable = distance <= 2f;
+        bool magicInRange = distance <= 4f;
+        fireButton.interactable = magicInRange;
+        rainButton.interactable = magicInRange;
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -137,9 +137,21 @@ public class GameManager : MonoBehaviour
         if (playerTeam.Count > 0)
         {
             CharacterController player = playerTeam[0];
-            int damage = Random.Range(10, 21);
-            player.TakeDamage(damage);
-            Debug.Log($"Player {player.name} takes {damage} damage. HP left: {player.hitPoints}");
+            CharacterController enemy = activePlayer;
+            if (enemy != null)
+            {
+                float distance = Vector3.Distance(enemy.transform.position, player.transform.position);
+                if (distance <= 2f)
+                {
+                    int damage = Random.Range(10, 21);
+                    player.TakeDamage(damage);
+                    Debug.Log($"Player {player.name} takes {damage} damage. HP left: {player.hitPoints}");
+                }
+                else
+                {
+                    Debug.Log("Player is too far away to be attacked.");
+                }
+            }
         }
 
         yield return new WaitForSeconds(0.5f);


### PR DESCRIPTION
## Summary
- Disable attack and magic buttons when targets are out of range
- Prevent player and enemy attacks if separated beyond allowed tiles

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68979cb9300c8328bcd1f955a552040c