### PR TITLE
Highlight attack range and enable target selection

### DIFF
--- a/Assets/Scripts/CharacterController.cs
+++ b/Assets/Scripts/CharacterController.cs
@@ -155,14 +155,16 @@ public class CharacterController : MonoBehaviour
         {
             return;
         }
+        if (ActionMenu.instance != null && ActionMenu.instance.TryExecuteAttackOn(this))
+        {
+            return;
+        }
         if (!isEnemy)
         {
             GameManager.instance.SelectCharacter(this);
             isMoving = true;
             ActionMenu.instance.HideMenu();
         }
-        isMoving = true;
-        ActionMenu.instance.HideMenu();
     }
 
     public void TakeDamage(int amount)

--- a/Assets/Scripts/MoveGrid.cs
+++ b/Assets/Scripts/MoveGrid.cs
@@ -67,6 +67,7 @@ public class MoveGrid : MonoBehaviour
         foreach (MovePoint movePoint in allMovePoints)
         {
             movePoint.gameObject.SetActive(false);
+            movePoint.ResetColor();
         }
     }
 
@@ -94,6 +95,19 @@ public class MoveGrid : MonoBehaviour
         foreach (MovePoint movePoint in pointsToShow)
         {
             movePoint.gameObject.SetActive(true);
+        }
+    }
+
+    public void ShowAttackRange(Vector3 center, int range)
+    {
+        HideMovePoints();
+
+        List<MovePoint> pointsToShow = GetPointsInRange(center, range);
+
+        foreach (MovePoint movePoint in pointsToShow)
+        {
+            movePoint.gameObject.SetActive(true);
+            movePoint.SetColor(Color.red);
         }
     }
 }

--- a/Assets/Scripts/MovePoint.cs
+++ b/Assets/Scripts/MovePoint.cs
@@ -2,6 +2,31 @@ using UnityEngine;
 
 public class MovePoint : MonoBehaviour
 {
+    private Renderer rend;
+    private Color defaultColor;
+
+    private void Awake()
+    {
+        rend = GetComponent<Renderer>();
+        if (rend != null)
+        {
+            defaultColor = rend.material.color;
+        }
+    }
+
+    public void SetColor(Color color)
+    {
+        if (rend != null)
+        {
+            rend.material.color = color;
+        }
+    }
+
+    public void ResetColor()
+    {
+        SetColor(defaultColor);
+    }
+
     private void OnMouseDown()
     {
         GameManager.instance.MoveActivePlayerToPoint(transform.position);


### PR DESCRIPTION
## Summary
- Show attackable hex tiles in red for physical and magic attacks
- Queue attacks on action selection and execute when an enemy within range is clicked
- Reset tile colors when hiding move points

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6897a2048ba883288c04a97df468f633