### PR TITLE
Keep attack buttons active and block hexagon clicks during attack

### DIFF
--- a/Assets/Scripts/ActionMenu.cs
+++ b/Assets/Scripts/ActionMenu.cs
@@ -233,14 +233,15 @@ public class ActionMenu : MonoBehaviour
             return;
         }
 
-        CharacterController player = GameManager.instance.activePlayer;
-        CharacterController enemy = GameManager.instance.enemyTeam[0];
-
-        float distance = Vector3.Distance(player.transform.position, enemy.transform.position);
-
-        attackButton.interactable = distance <= 2f;
-        bool magicInRange = distance <= 4f;
-        fireButton.interactable = magicInRange;
-        rainButton.interactable = magicInRange;
+        // Always allow the action buttons to be interacted with if both
+        // a player and an enemy exist.  The actual range validation is
+        // handled when the player attempts to execute the attack in
+        // TryExecuteAttackOn.  Previously these buttons were disabled when
+        // the enemy was out of range, which prevented the player from
+        // selecting an attack at all.  This change keeps them enabled so the
+        // player can choose an attack even if the enemy is far away.
+        attackButton.interactable = true;
+        fireButton.interactable = true;
+        rainButton.interactable = true;
     }
 }

--- a/Assets/Scripts/MoveGrid.cs
+++ b/Assets/Scripts/MoveGrid.cs
@@ -68,6 +68,9 @@ public class MoveGrid : MonoBehaviour
         {
             movePoint.gameObject.SetActive(false);
             movePoint.ResetColor();
+            // Ensure move points are clickable again the next time they are
+            // shown for movement.
+            movePoint.SetClickable(true);
         }
     }
 
@@ -95,6 +98,7 @@ public class MoveGrid : MonoBehaviour
         foreach (MovePoint movePoint in pointsToShow)
         {
             movePoint.gameObject.SetActive(true);
+            movePoint.SetClickable(true);
         }
     }
 
@@ -108,6 +112,9 @@ public class MoveGrid : MonoBehaviour
         {
             movePoint.gameObject.SetActive(true);
             movePoint.SetColor(Color.red);
+            // Disable clicking on attack range hexagons; only enemies should
+            // be clickable when an attack is pending.
+            movePoint.SetClickable(false);
         }
     }
 }

--- a/Assets/Scripts/MovePoint.cs
+++ b/Assets/Scripts/MovePoint.cs
@@ -4,10 +4,13 @@ public class MovePoint : MonoBehaviour
 {
     private Renderer rend;
     private Color defaultColor;
+    private Collider col;
 
     private void Awake()
     {
         rend = GetComponent<Renderer>();
+        col = GetComponent<Collider>();
+
         if (rend != null)
         {
             defaultColor = rend.material.color;
@@ -25,6 +28,14 @@ public class MovePoint : MonoBehaviour
     public void ResetColor()
     {
         SetColor(defaultColor);
+    }
+
+    public void SetClickable(bool clickable)
+    {
+        if (col != null)
+        {
+            col.enabled = clickable;
+        }
     }
 
     private void OnMouseDown()


### PR DESCRIPTION
## Summary
- Allow Attack, Fire, and Rain buttons to stay active regardless of distance
- Add toggleable collider on move points and disable them when showing attack range
- Ensure attack range hexagons are visual only and only enemy can be clicked

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897a52057c48328b91d1119cffe8dc2