### PR TITLE
Fix attack turn cancellation logic

### DIFF
--- a/Assets/Scripts/ActionMenu.cs
+++ b/Assets/Scripts/ActionMenu.cs
@@ -133,7 +133,8 @@ public class ActionMenu : MonoBehaviour
             player.Heal(healAmount);
             Debug.Log($"Player {player.name} rests and recovers {healAmount} HP. HP now: {player.hitPoints}");
         }
-
+        MoveGrid.instance.HideMovePoints();
+        pendingAttack = PendingAttack.None;
         CompletePlayerAction();
     }
 
@@ -186,9 +187,7 @@ public class ActionMenu : MonoBehaviour
         float distance = Vector3.Distance(player.transform.position, target.transform.position);
         if (distance > pendingRange || !target.isEnemy)
         {
-            MoveGrid.instance.HideMovePoints();
-            pendingAttack = PendingAttack.None;
-            return false;
+            return true;
         }
 
         int damage = 0;


### PR DESCRIPTION
## Summary
- keep attack mode active until an attack is executed or rest is chosen
- ignore clicks on players or out-of-range enemies during attack mode

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897a80707d4832880c581aa68831a8b